### PR TITLE
Run the lint of the charts in the CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,24 @@
+name: Lint Charts
+
+on:
+  push:
+
+jobs:
+  lint:
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Lint Helm Charts
+        run: |
+          helm lint zazuko/*


### PR DESCRIPTION
This makes sure that the Helm Charts are valid on each commit.