### PR TITLE
Remove duplicated section in the generated README files

### DIFF
--- a/.github/docs/helm-docs.tpl.md
+++ b/.github/docs/helm-docs.tpl.md
@@ -24,5 +24,3 @@ helm install {{ template "chart.name" . }} zazuko/{{ template "chart.name" . }}
 {{ template "chart.requirementsSection" . }}
 
 {{ template "chart.sourcesSection" . }}
-
-{{ template "chart.requirementsSection" . }}


### PR DESCRIPTION
This fixes an issue where the dependencies section was duplicated in the generated README files.